### PR TITLE
Split Boilerplate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
+*.log
+*.retry
 .vagrant/

--- a/tests/boilerplate.yml
+++ b/tests/boilerplate.yml
@@ -1,0 +1,28 @@
+---
+
+- hosts: all
+  become: True
+
+  tasks:
+    - name: Update local apt cache (Ubuntu)
+      apt:
+        update_cache: True
+      when: ansible_os_family == 'Debian'
+
+    - name: Install policycoreutils-python
+      yum:
+        name: 'policycoreutils-python'
+        state: present
+      when: ansible_os_family == 'RedHat'
+
+    # Workaround for selinux errors when using sqlite DB
+    - name: Set permissive SElinux for httpd domain
+      selinux_permissive:
+        name: 'httpd_t'
+        permissive: True
+      when:
+        - ansible_selinux
+        - ansible_virtualization_type != 'docker'
+
+  roles:
+    - openstack-repo

--- a/tests/requirements.yml
+++ b/tests/requirements.yml
@@ -1,12 +1,12 @@
 ---
 
-- name: 'openstack-keystone'
-  src: 'https://github.com/openstack-ansible-galaxy/openstack-keystone'
-  version: 'origin/features/mitaka'
-
-- name: 'rabbitmq'
-  src: 'https://github.com/abelboldu/ansible-rabbitmq'
-  version: 'master'
+- name: 'openstack-repo'
+  src: 'abelboldu.openstack-repo'
 
 - name: 'mysql'
   src: 'geerlingguy.mysql'
+
+- src: 'https://github.com/openstack-ansible-galaxy/rabbitmq.git'
+
+- src: 'https://github.com/openstack-ansible-galaxy/openstack-keystone'
+  version: 'features/mitaka'

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -1,42 +1,9 @@
 ---
 
+- include: boilerplate.yml
+
 - hosts: all
   become: True
-
-  pre_tasks:
-    - block:
-        - name: Update local apt cache
-          apt:
-            update_cache: True
-
-        - name: Install Ubuntu Cloud archive keyring (Debian)
-          apt:
-            name: 'ubuntu-cloud-keyring'
-            state: present
-
-        - name: Enable OpenStack (Debian)
-          apt_repository:
-            repo: 'deb http://ubuntu-cloud.archive.canonical.com/ubuntu trusty-updates/mitaka main'
-            state: present
-      when: ansible_os_family == 'Debian'
-
-    - name: Enable OpenStack (RedHat)
-      yum:
-        name: '{{ item }}'
-        state: present
-      with_items:
-        - 'centos-release-openstack-mitaka'
-        - 'policycoreutils-python'
-      when: ansible_os_family == 'RedHat'
-
-    # Workaround for selinux errors when using sqlite DB
-    - name: Set permissive SElinux for httpd domain
-      selinux_permissive:
-        name: 'httpd_t'
-        permissive: True
-      when:
-        - ansible_selinux
-        - ansible_virtualization_type != 'docker'
 
   roles:
     - role: mysql


### PR DESCRIPTION
Since all roles will have a boilerplate, it will be easier to split the
boilerplate into a dedicated file so that if and when the boilerplate is
updated, it will be just a matter of copying files around.

Signed-off-by: Ryo Tagami rtagami@airstrip.jp
