### PR TITLE
Dynamic Database Migration Version Detection

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,7 +3,6 @@
 # Heat
 openstack_heat_pass: 'heat_pass_default'
 openstack_heat_database_url: 'sqlite:////var/lib/heat/heat.db'
-openstack_heat_database_schema_version: 27
 openstack_heat_metadata_server_url: 'http://localhost:8000'
 openstack_heat_waitcondition_server_url: 'http://localhost:8000/v1/waitcondition'
 openstack_heat_run_sanity_check: False

--- a/tasks/facts.yml
+++ b/tasks/facts.yml
@@ -1,15 +1,19 @@
 ---
 
 - name: 'openstack_heat.tasks.facts: Set service facts for Debian family'
-  when: ansible_os_family == 'Debian'
   set_fact:
     openstack_heat_api_service: 'heat-api'
     openstack_heat_api_cfn_service: 'heat-api-cfn'
     openstack_heat_engine_service: 'heat-engine'
+    openstack_heat_database_migration_repository: >-
+      /usr/lib/python2.7/dist-packages/heat/db/sqlalchemy/migrate_repo/versions
+  when: ansible_os_family == 'Debian'
 
 - name: 'openstack_heat.tasks.facts: Set service facts for RedHat family'
-  when: ansible_os_family == 'RedHat'
   set_fact:
     openstack_heat_api_service: 'openstack-heat-api'
     openstack_heat_api_cfn_service: 'openstack-heat-api-cfn'
     openstack_heat_engine_service: 'openstack-heat-engine'
+    openstack_heat_database_migration_repository: >-
+      /usr/lib/python2.7/site-packages/heat/db/sqlalchemy/migrate_repo/versions
+  when: ansible_os_family == 'RedHat'

--- a/tasks/services.yml
+++ b/tasks/services.yml
@@ -1,15 +1,25 @@
 ---
 
+- name: 'openstack_heat.tasks.services: Get latest Heat database version'
+  shell: >-
+    ls {{ openstack_heat_database_migration_repository }}
+    | grep '^[0-9]\{3\}_' | sort -n | tail -n 1 | awk -F '_' '{ print $1; }'
+  always_run: True
+  changed_when: False
+  register: openstack_heat_database_schema_version
+
 - name: 'openstack_heat.tasks.services: Get current heat database version'
   command: 'heat-manage db_version'
   always_run: True
   become: True
   become_user: 'heat'
-  changed_when: openstack_heat_manage_db_version.stdout|int != openstack_heat_database_schema_version
+  changed_when: >-
+    openstack_heat_manage_db_version.stdout|int
+    != openstack_heat_database_schema_version.stdout|int
   register: openstack_heat_manage_db_version
 
 - name: 'openstack_heat.tasks.services: Migrate heat database to desired version'
-  command: 'heat-manage db_sync {{ heat_database_schema_version }}'
+  command: 'heat-manage db_sync {{ openstack_heat_database_schema_version.stdout }}'
   become: True
   become_user: 'heat'
   when: openstack_heat_manage_db_version|changed


### PR DESCRIPTION
Dynamically detect the latest database migration version, instead of
hardcoding the latest database migration version, which is difficult to
keep up with the upstream changes.

Signed-off-by: Ryo Tagami <rtagami@airstrip.jp>